### PR TITLE
Removes www from contact link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A site to answer [How old is the internet?](https://howoldistheinter.net/).
 
 ## Team
 
-Development: [Tosbourn Ltd](https://www.tosbourn.com/)
+Development: [Tosbourn Ltd](https://tosbourn.com/)
 
 Contact: [toby@tosbourn.com](mailto:toby@tosbourn.com)
 

--- a/index.php
+++ b/index.php
@@ -290,7 +290,7 @@
           <div class="timeline-element">
             <time datetime="<?= date("Y"); ?>"><?= date("Y"); ?> - day <span class="day-highlight"><?=$web_days; ?></span></time>
             <h3>NOW</h3>
-            Something we left out? Something happened that you think we should include? <a href="https://www.tosbourn.com/contact/">Contact us!</a>
+            Something we left out? Something happened that you think we should include? <a href="https://tosbourn.com/contact/">Contact us!</a>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
The www on the contact link redirects on tosbourn.com so this has been removed.

Closes #42